### PR TITLE
📞 Adiciona as telas de Status e Chamadas ao clone do WhatsApp

### DIFF
--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/CallItem.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/CallItem.kt
@@ -1,0 +1,48 @@
+package com.murilospinello2025.androidcompose.domain.model
+
+
+sealed class CallItem {
+    data class Favorite(
+        val name: String,
+        val profileImageUrl: String
+    ) : CallItem()
+
+    data class Recent(
+        val name: String,
+        val profileImageUrl: String,
+        val direction: CallDirection,
+        val dateTime: String,
+        val isVideoCall: Boolean
+    ) : CallItem()
+}
+
+enum class CallDirection {
+    INCOMING,
+    OUTGOING,
+    MISSED
+}
+
+val sampleCalls = listOf(
+    CallItem.Favorite(
+        name = "Herick",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    ),
+    CallItem.Favorite(
+        name = "Estenio",
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    CallItem.Recent(
+        name = "Nayara",
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg",
+        direction = CallDirection.INCOMING,
+        dateTime = "Hoje 12:45",
+        isVideoCall = false
+    ),
+    CallItem.Recent(
+        name = "Herick",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg",
+        direction = CallDirection.OUTGOING,
+        dateTime = "Ontem 11:30",
+        isVideoCall = true
+    )
+)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/ChatItem.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/ChatItem.kt
@@ -36,5 +36,5 @@ val sampleChats = listOf(
         time = "Ontem",
         unreadCount = 1,
         profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
-    ),
+    )
 )

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/StatusItem.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/StatusItem.kt
@@ -1,0 +1,35 @@
+package com.murilospinello2025.androidcompose.domain.model
+
+sealed class StatusItem {
+    data class ContactStatus(
+        val id: String,
+        val name: String,
+        val time: String,
+        val profileImageUrl: String
+    ) : StatusItem()
+
+    data object MyStatus : StatusItem()
+}
+
+
+val sampleStatuses = listOf(
+    StatusItem.MyStatus,
+    StatusItem.ContactStatus(
+        id = "1",
+        name = "Estenio",
+        time = "há 10 min",
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    StatusItem.ContactStatus(
+        id = "2",
+        name = "Nayara",
+        time = "há 23 min",
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg"
+    ),
+    StatusItem.ContactStatus(
+        id = "3",
+        name = "Herick",
+        time = "há 1h",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    )
+)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/CallsScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/CallsScreen.kt
@@ -1,0 +1,150 @@
+package com.murilospinello2025.androidcompose.ui.home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.rememberAsyncImagePainter
+import com.murilospinello2025.androidcompose.domain.model.CallDirection
+import com.murilospinello2025.androidcompose.domain.model.CallItem
+import com.murilospinello2025.androidcompose.domain.model.sampleCalls
+import com.murilospinello2025.androidcompose.ui.theme.Dimens
+
+@Preview
+@Composable
+fun CallsScreen() {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item {
+            Text(
+                text = "Ligações",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS)
+            )
+        }
+
+        item {
+            Text(
+                text = "Favoritos",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS)
+            )
+        }
+
+        items(sampleCalls.filterIsInstance<CallItem.Favorite>()) { call ->
+            FavoriteCallItem(call)
+        }
+
+        item {
+            Text(
+                text = "Recentes",
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS)
+            )
+        }
+
+        items(sampleCalls.filterIsInstance<CallItem.Recent>()) { call ->
+            RecentCallItem(call)
+        }
+    }
+}
+
+@Composable
+fun FavoriteCallItem(call: CallItem.Favorite) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(call.profileImageUrl),
+            contentDescription = call.name,
+            modifier = Modifier
+                .size(Dimens.chatImageSize)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop
+        )
+        Spacer(modifier = Modifier.width(Dimens.spacingM))
+        Text(call.name, style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.weight(1f))
+        Icon(imageVector = Icons.Default.Call, contentDescription = "Chamada")
+        Spacer(modifier = Modifier.width(Dimens.spacingS))
+        Icon(imageVector = Icons.Default.PlayArrow, contentDescription = "Vídeo")
+    }
+}
+
+@Composable
+fun RecentCallItem(call: CallItem.Recent) {
+    val arrowIcon = when (call.direction) {
+        CallDirection.INCOMING -> Icons.Default.Call
+        CallDirection.OUTGOING -> Icons.AutoMirrored.Filled.ArrowBack
+        CallDirection.MISSED -> Icons.AutoMirrored.Filled.ArrowForward
+    }
+
+    val arrowColor = when (call.direction) {
+        CallDirection.INCOMING -> Color(0xFF00C853)
+        CallDirection.OUTGOING -> Color(0xFF00C853)
+        CallDirection.MISSED -> Color.Red
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(call.profileImageUrl),
+            contentDescription = call.name,
+            modifier = Modifier
+                .size(Dimens.chatImageSize)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop
+        )
+        Spacer(modifier = Modifier.width(Dimens.spacingM))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(call.name, style = MaterialTheme.typography.titleMedium)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = arrowIcon,
+                    contentDescription = null,
+                    tint = arrowColor,
+                    modifier = Modifier.size(Dimens.spacingL)
+                )
+                Spacer(modifier = Modifier.width(Dimens.spacingXS))
+                Text(call.dateTime, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+        Icon(
+            imageVector = if (call.isVideoCall) Icons.Default.PlayArrow else Icons.Default.Call,
+            contentDescription = null
+        )
+    }
+}
+
+

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/MainActivity.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/MainActivity.kt
@@ -1,35 +1,26 @@
 package com.murilospinello2025.androidcompose.ui.home
 
-import ChatsScreen
+import com.murilospinello2025.androidcompose.ui.home.chats.ChatsScreen
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.murilospinello2025.androidcompose.ui.home.chats.WhatsAppTab
 import com.murilospinello2025.androidcompose.ui.theme.AndroidComposeMuriloSpinello2025Theme
 import kotlinx.coroutines.launch
 
@@ -89,13 +80,3 @@ fun WhatsAppWithSwipe() {
     }
 }
 
-
-@Composable
-fun StatusScreen() {
-    Text("Status dos contatos")
-}
-
-@Composable
-fun CallsScreen() {
-    Text("Histórico de chamadas")
-}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/StatusScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/StatusScreen.kt
@@ -1,0 +1,111 @@
+package com.murilospinello2025.androidcompose.ui.home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.rememberAsyncImagePainter
+import com.murilospinello2025.androidcompose.domain.model.StatusItem
+import com.murilospinello2025.androidcompose.domain.model.sampleStatuses
+import com.murilospinello2025.androidcompose.ui.theme.Dimens
+
+@Preview
+@Composable
+fun StatusScreen() {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(vertical = Dimens.spacingS)
+    ) {
+        items(sampleStatuses) { status ->
+            when (status) {
+                is StatusItem.MyStatus -> MyStatusItem()
+                is StatusItem.ContactStatus -> ContactStatusItem(status)
+            }
+        }
+    }
+}
+
+@Composable
+fun MyStatusItem() {
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                painter = rememberAsyncImagePainter("https://i.pinimg.com/236x/19/8a/bd/198abd0730e616bf1c3afc692d16f2ac.jpg"),
+                contentDescription = "Meu Status",
+                modifier = Modifier
+                    .size(Dimens.chatImageSize)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop
+            )
+            Spacer(modifier = Modifier.width(Dimens.spacingM))
+            Column {
+                Text("Meu Status", style = MaterialTheme.typography.titleMedium)
+                Text("agora mesmo", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+
+        HorizontalDivider(
+            modifier = Modifier
+                .padding(top = Dimens.spacingM, bottom = Dimens.spacingXS)
+                .fillMaxWidth()
+        )
+
+        Text(
+            text = "ATUALIZAÇÕES RECENTES",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS)
+        )
+    }
+
+}
+
+@Composable
+fun ContactStatusItem(status: StatusItem.ContactStatus) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(status.profileImageUrl),
+            contentDescription = status.name,
+            modifier = Modifier
+                .size(Dimens.chatImageSize)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop
+        )
+        Spacer(modifier = Modifier.width(Dimens.spacingM))
+        Column {
+            Text(status.name, style = MaterialTheme.typography.titleMedium)
+            Text(status.time, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsScreen.kt
@@ -1,3 +1,5 @@
+package com.murilospinello2025.androidcompose.ui.home.chats
+
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/WhatsAppTab.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/WhatsAppTab.kt
@@ -1,4 +1,4 @@
-package com.murilospinello2025.androidcompose.ui.home
+package com.murilospinello2025.androidcompose.ui.home.chats
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Call

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/theme/Dimens.kt
@@ -7,6 +7,8 @@ object Dimens {
     val spacingXS = 4.dp
     val spacingS = 8.dp
     val spacingM = 12.dp
+    val spacingL =  16.dp
+
 
     val chatImageSize = 54.dp
     val chatDividerStartPadding = 80.dp


### PR DESCRIPTION
# 📞 Adiciona as telas de Status e Chamadas ao clone do WhatsApp

## ✅ Descrição

Este Pull Request implementa duas novas telas funcionais no projeto: **Status** e **Chamadas**, seguindo o padrão de design do WhatsApp original e boas práticas com **Jetpack Compose**, **separation of concerns** e uso de `sealed class` para modelagem de dados.

---

## 🆕 Arquivos adicionados

### 📁 domain/model

- `CallItem.kt`: 
  - Criação de uma `sealed class` representando dois tipos de chamadas: `Favorite` e `Recent`.
  - Uso de `enum class CallDirection` para identificar chamadas de entrada, saída ou perdidas.
  - Modelagem preparada para suporte a chamadas de áudio ou vídeo.

- `StatusItem.kt`:
  - Criação da `sealed class` que representa o item do status.
  - `MyStatus` como tipo fixo e `ContactStatus` com nome, horário e imagem de perfil para representar os status recentes.

---

### 📁 ui/home

- `CallsScreen.kt`:
  - Tela de chamadas estruturada com seções de **Favoritos** e **Recentes**.
  - Uso de `LazyColumn`, `Row`, `Image`, `Icon` e tokens visuais centralizados (via `Dimens`).
  - Os ícones de chamada e vídeo são exibidos com base nos dados.
  - Direção das ligações representada por setas coloridas (verde/vermelho), similar à interface do WhatsApp real.

- `StatusScreen.kt`:
  - Implementação da tela de status baseada na UI do WhatsApp.
  - Exibição do "Meu Status" com imagem circular e status recente como lista de contatos.
  - Utiliza `LazyColumn` e separadores visuais entre seções.
  - Pronta para receber clique ou lógica futura para criar/visualizar status.

---

## 🧱 Técnicas e boas práticas aplicadas

- Uso extensivo de **sealed classes** para organizar os modelos de dados da UI.
- Layouts componíveis e reutilizáveis, seguindo princípios de **Single Responsibility**.
- Estilização baseada em tokens definidos no `Dimens.kt`, garantindo consistência visual.
- Separação clara entre **camada de dados (`domain/model`)** e **camada de UI (`ui/home`)**.
- Estrutura já preparada para expansão futura (ViewModel, navegação, actions).

---

## 🔜 Próximos passos sugeridos

- Adicionar navegação entre as telas usando **Navigation Compose**.
- Adicionar botão flutuante de ação (FAB) nas telas de chamadas e status.
- Criar lógica de click nos itens (ex: visualizar status, iniciar chamada).
- Futuramente, integrar ViewModels com fluxos de dados reativos (StateFlow).

---

📌 Pull Request pronto para revisão.
Feedbacks são muito bem-vindos!
