### PR TITLE
🚀 Estruturação de Camadas e ViewModels por Feature

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,61 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/java/com/murilospinello2025/StringUtils.kt
+++ b/app/src/main/java/com/murilospinello2025/StringUtils.kt
@@ -1,0 +1,3 @@
+package com.murilospinello2025
+
+fun emptyString() = ""

--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/local/CallsDataSourceMock.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/local/CallsDataSourceMock.kt
@@ -1,0 +1,35 @@
+package com.murilospinello2025.androidcompose.data.local
+
+import com.murilospinello2025.androidcompose.domain.model.CallDirection
+import com.murilospinello2025.androidcompose.domain.model.CallItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class CallsDataSourceMock {
+    fun fetchCalls(): Flow<List<CallItem>> = flowOf(sampleCalls)
+}
+
+val sampleCalls = listOf(
+    CallItem.Favorite(
+        name = "Herick",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    ),
+    CallItem.Favorite(
+        name = "Estenio",
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    CallItem.Recent(
+        name = "Nayara",
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg",
+        direction = CallDirection.INCOMING,
+        dateTime = "Hoje 12:45",
+        isVideoCall = false
+    ),
+    CallItem.Recent(
+        name = "Herick",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg",
+        direction = CallDirection.OUTGOING,
+        dateTime = "Ontem 11:30",
+        isVideoCall = true
+    )
+)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/CallsRepositoryImpl.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/CallsRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.murilospinello2025.androidcompose.data.repository
+
+
+import com.murilospinello2025.androidcompose.data.local.CallsDataSourceMock
+import com.murilospinello2025.androidcompose.domain.model.CallItem
+import com.murilospinello2025.androidcompose.domain.repository.CallsRepository
+import kotlinx.coroutines.flow.Flow
+
+class CallsRepositoryImpl(
+    private val dataSource: CallsDataSourceMock
+) : CallsRepository {
+    override fun getCalls(): Flow<List<CallItem>> = dataSource.fetchCalls()
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/di/AppModule.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/di/AppModule.kt
@@ -1,7 +1,26 @@
 package com.murilospinello2025.androidcompose.di
 
+import com.murilospinello2025.androidcompose.data.local.CallsDataSourceMock
+import com.murilospinello2025.androidcompose.data.repository.CallsRepositoryImpl
+import com.murilospinello2025.androidcompose.domain.repository.CallsRepository
+import com.murilospinello2025.androidcompose.domain.usecase.GetCallsUseCase
+import com.murilospinello2025.androidcompose.ui.home.MainViewModel
+import com.murilospinello2025.androidcompose.ui.home.calls.CallsViewModel
+import com.murilospinello2025.androidcompose.ui.home.chats.ChatsViewModel
+import com.murilospinello2025.androidcompose.ui.home.status.StatusViewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val appModule = module {
 
+    viewModelOf(::MainViewModel)
+    viewModelOf(::CallsViewModel)
+    viewModelOf(::ChatsViewModel)
+    viewModelOf(::StatusViewModel)
+
+    singleOf(::GetCallsUseCase)
+    singleOf(::CallsRepositoryImpl) bind CallsRepository::class
+    singleOf(::CallsDataSourceMock)
 }

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/CallItem.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/CallItem.kt
@@ -21,28 +21,3 @@ enum class CallDirection {
     OUTGOING,
     MISSED
 }
-
-val sampleCalls = listOf(
-    CallItem.Favorite(
-        name = "Herick",
-        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
-    ),
-    CallItem.Favorite(
-        name = "Estenio",
-        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
-    ),
-    CallItem.Recent(
-        name = "Nayara",
-        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg",
-        direction = CallDirection.INCOMING,
-        dateTime = "Hoje 12:45",
-        isVideoCall = false
-    ),
-    CallItem.Recent(
-        name = "Herick",
-        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg",
-        direction = CallDirection.OUTGOING,
-        dateTime = "Ontem 11:30",
-        isVideoCall = true
-    )
-)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/repository/CallsRepository.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/repository/CallsRepository.kt
@@ -1,0 +1,8 @@
+package com.murilospinello2025.androidcompose.domain.repository
+
+import com.murilospinello2025.androidcompose.domain.model.CallItem
+import kotlinx.coroutines.flow.Flow
+
+interface CallsRepository {
+    fun getCalls(): Flow<List<CallItem>>
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/usecase/GetCallsUseCase.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/usecase/GetCallsUseCase.kt
@@ -1,0 +1,9 @@
+package com.murilospinello2025.androidcompose.domain.usecase
+
+import com.murilospinello2025.androidcompose.domain.model.CallItem
+import com.murilospinello2025.androidcompose.domain.repository.CallsRepository
+import kotlinx.coroutines.flow.Flow
+
+class GetCallsUseCase(private val repository: CallsRepository) {
+    operator fun invoke(): Flow<List<CallItem>> = repository.getCalls()
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/MainActivity.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.murilospinello2025.androidcompose.ui.home
 
-import com.murilospinello2025.androidcompose.ui.home.chats.ChatsScreen
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -17,36 +16,50 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.murilospinello2025.androidcompose.ui.home.chats.WhatsAppTab
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.murilospinello2025.androidcompose.ui.home.calls.CallsScreen
+import com.murilospinello2025.androidcompose.ui.home.chats.ChatsScreen
+import com.murilospinello2025.androidcompose.ui.home.status.StatusScreen
 import com.murilospinello2025.androidcompose.ui.theme.AndroidComposeMuriloSpinello2025Theme
 import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : ComponentActivity() {
+    private val mainViewModel: MainViewModel by viewModel()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             AndroidComposeMuriloSpinello2025Theme {
-                WhatsAppWithSwipe()
+                WhatsAppWithSwipe(mainViewModel)
             }
         }
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Preview
 @Composable
-fun WhatsAppWithSwipe() {
+fun WhatsAppWithSwipe(mainViewModel: MainViewModel) {
     val tabs = WhatsAppTab.items
-    val pagerState = rememberPagerState(pageCount = { tabs.size })
     val coroutineScope = rememberCoroutineScope()
+    val pagerState = rememberPagerState(pageCount = { tabs.size })
+    val title by mainViewModel.titlePage.collectAsStateWithLifecycle()
+
+    LaunchedEffect(pagerState.currentPage) {
+        mainViewModel.setTitlePage(tabs[pagerState.currentPage].title)
+    }
+
 
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("WhatsApp Murilo") })
+            TopAppBar(title = { Text(title) })
         },
         bottomBar = {
             NavigationBar {
@@ -80,3 +93,9 @@ fun WhatsAppWithSwipe() {
     }
 }
 
+@Preview
+@Composable
+fun WhatsAppWithSwipePreview() {
+    val previewViewModel = remember { MainViewModel() }
+    WhatsAppWithSwipe(mainViewModel = previewViewModel)
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/MainViewModel.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/MainViewModel.kt
@@ -1,0 +1,20 @@
+package com.murilospinello2025.androidcompose.ui.home
+
+import androidx.lifecycle.ViewModel
+import com.murilospinello2025.emptyString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class MainViewModel: ViewModel() {
+
+    private val _titlePage = MutableStateFlow<String>(emptyString())
+    val titlePage = _titlePage.asStateFlow()
+
+    fun setTitlePage(title: String) {
+        _titlePage.value = "$TAG $title"
+    }
+
+    companion object {
+        private const val TAG = "Whatsapp"
+    }
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/WhatsAppTab.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/WhatsAppTab.kt
@@ -1,4 +1,4 @@
-package com.murilospinello2025.androidcompose.ui.home.chats
+package com.murilospinello2025.androidcompose.ui.home
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Call

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/calls/CallsScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/calls/CallsScreen.kt
@@ -1,4 +1,4 @@
-package com.murilospinello2025.androidcompose.ui.home
+package com.murilospinello2025.androidcompose.ui.home.calls
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
@@ -10,13 +10,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Call
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
@@ -29,47 +28,83 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
 import com.murilospinello2025.androidcompose.domain.model.CallDirection
 import com.murilospinello2025.androidcompose.domain.model.CallItem
-import com.murilospinello2025.androidcompose.domain.model.sampleCalls
 import com.murilospinello2025.androidcompose.ui.theme.Dimens
+import org.koin.androidx.compose.koinViewModel
+import androidx.compose.runtime.getValue
+
+
+@Composable
+fun CallsScreen() {
+    val viewModel: CallsViewModel = koinViewModel()
+    val calls by viewModel.calls.collectAsStateWithLifecycle()
+
+    val favorites = calls.filterIsInstance<CallItem.Favorite>()
+    val recents = calls.filterIsInstance<CallItem.Recent>()
+
+
+    CallsColumn {
+        favoriteSection(favorites)
+        recentSection(recents)
+    }
+}
 
 @Preview
 @Composable
-fun CallsScreen() {
+fun CallsScreenPreview() {
+    val favorites = sampleCallsPreview.filterIsInstance<CallItem.Favorite>()
+    val recents = sampleCallsPreview.filterIsInstance<CallItem.Recent>()
+
+    CallsColumn {
+        favoriteSection(favorites)
+        recentSection(recents)
+    }
+}
+
+@Composable
+fun CallsColumn(content: LazyListScope.() -> Unit) {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
         item {
             Text(
                 text = "Ligações",
                 style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS)
+                modifier = Modifier.padding(
+                    horizontal = Dimens.spacingL,
+                    vertical = Dimens.spacingS
+                )
             )
         }
 
+        content()
+    }
+}
+
+fun LazyListScope.favoriteSection(favorites: List<CallItem.Favorite>) {
+    if (favorites.isNotEmpty()) {
         item {
             Text(
                 text = "Favoritos",
                 style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS)
+                modifier = Modifier.padding(horizontal = Dimens.spacingL)
             )
         }
+        items(favorites) { FavoriteCallItem(it) }
+    }
+}
 
-        items(sampleCalls.filterIsInstance<CallItem.Favorite>()) { call ->
-            FavoriteCallItem(call)
-        }
-
+fun LazyListScope.recentSection(recents: List<CallItem.Recent>) {
+    if (recents.isNotEmpty()) {
         item {
             Text(
                 text = "Recentes",
                 style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.padding(horizontal = Dimens.spacingL, vertical = Dimens.spacingS)
+                modifier = Modifier.padding(horizontal = Dimens.spacingL)
             )
         }
-
-        items(sampleCalls.filterIsInstance<CallItem.Recent>()) { call ->
-            RecentCallItem(call)
-        }
+        items(recents) { RecentCallItem(it) }
     }
 }
 
@@ -146,5 +181,30 @@ fun RecentCallItem(call: CallItem.Recent) {
         )
     }
 }
+
+private val sampleCallsPreview = listOf(
+    CallItem.Favorite(
+        name = "Herick",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    ),
+    CallItem.Favorite(
+        name = "Estenio",
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    CallItem.Recent(
+        name = "Nayara",
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg",
+        direction = CallDirection.INCOMING,
+        dateTime = "Hoje 12:45",
+        isVideoCall = false
+    ),
+    CallItem.Recent(
+        name = "Herick",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg",
+        direction = CallDirection.OUTGOING,
+        dateTime = "Ontem 11:30",
+        isVideoCall = true
+    )
+)
 
 

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/calls/CallsViewModel.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/calls/CallsViewModel.kt
@@ -1,0 +1,32 @@
+package com.murilospinello2025.androidcompose.ui.home.calls
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.murilospinello2025.androidcompose.domain.model.CallItem
+import com.murilospinello2025.androidcompose.domain.usecase.GetCallsUseCase
+import com.murilospinello2025.emptyString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
+
+class CallsViewModel(
+    getCallsUseCase: GetCallsUseCase
+): ViewModel() {
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
+
+    val calls: StateFlow<List<CallItem>> = getCallsUseCase()
+        .catch { e ->
+            _error.value = e.message ?: "Erro desconhecido"
+            emit(emptyList())
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsScreen.kt
@@ -28,10 +28,12 @@ import coil.compose.rememberAsyncImagePainter
 import com.murilospinello2025.androidcompose.domain.model.ChatItem
 import com.murilospinello2025.androidcompose.domain.model.sampleChats
 import com.murilospinello2025.androidcompose.ui.theme.Dimens
+import org.koin.androidx.compose.koinViewModel
 
 @Preview
 @Composable
 fun ChatsScreen() {
+    val viewModel: ChatsViewModel = koinViewModel()
     val horizontalColorDivider = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f)
 
     LazyColumn(

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsViewModel.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsViewModel.kt
@@ -1,0 +1,20 @@
+package com.murilospinello2025.androidcompose.ui.home.chats
+
+import androidx.lifecycle.ViewModel
+import com.murilospinello2025.emptyString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class ChatsViewModel: ViewModel() {
+
+    private val _titlePage = MutableStateFlow<String>(emptyString())
+    val titlePage = _titlePage.asStateFlow()
+
+    fun setTitlePage(title: String) {
+        _titlePage.value = "$TAG $title"
+    }
+
+    companion object {
+        private const val TAG = "Whatsapp"
+    }
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusScreen.kt
@@ -1,4 +1,4 @@
-package com.murilospinello2025.androidcompose.ui.home
+package com.murilospinello2025.androidcompose.ui.home.status
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
@@ -26,10 +26,13 @@ import coil.compose.rememberAsyncImagePainter
 import com.murilospinello2025.androidcompose.domain.model.StatusItem
 import com.murilospinello2025.androidcompose.domain.model.sampleStatuses
 import com.murilospinello2025.androidcompose.ui.theme.Dimens
+import org.koin.androidx.compose.koinViewModel
 
 @Preview
 @Composable
 fun StatusScreen() {
+    val viewModel: StatusViewModel = koinViewModel()
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(vertical = Dimens.spacingS)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusViewModel.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusViewModel.kt
@@ -1,0 +1,20 @@
+package com.murilospinello2025.androidcompose.ui.home.status
+
+import androidx.lifecycle.ViewModel
+import com.murilospinello2025.emptyString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class StatusViewModel: ViewModel() {
+
+    private val _titlePage = MutableStateFlow<String>(emptyString())
+    val titlePage = _titlePage.asStateFlow()
+
+    fun setTitlePage(title: String) {
+        _titlePage.value = "$TAG $title"
+    }
+
+    companion object {
+        private const val TAG = "Whatsapp"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,6 @@ compose-pager = { group = "androidx.compose.foundation", name = "foundation", ve
 # Koin
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
-koin-androidx-workmanager = { group = "io.insert-koin", name = "koin-androidx-workmanager", version.ref = "koin" }
 koin-androidx-navigation = { group = "io.insert-koin", name = "koin-androidx-navigation", version.ref = "koin" }
 koin-test = { group = "io.insert-koin", name = "koin-test", version.ref = "koin" }
 koin-test-junit4 = { group = "io.insert-koin", name = "koin-test-junit4", version.ref = "koin" }


### PR DESCRIPTION
# 🚀 Estruturação de Camadas e ViewModels por Feature

Este Pull Request realiza uma importante organização no projeto, estruturando o padrão **MVVM + Clean Architecture** por feature e iniciando a divisão entre dados mockados, use cases, repositórios e ViewModels específicos.

---

## ✅ Alterações Realizadas

### 📦 Camada de dados
- `CallsDataSourceMock.kt`: Fonte de dados local mockada com a lista de chamadas.
- `CallsRepositoryImpl.kt`: Implementação concreta do repositório de chamadas.

### 📦 Camada de domínio
- `CallsRepository.kt`: Interface representando a fonte de dados para chamadas.
- `GetCallsUseCase.kt`: Caso de uso responsável por expor o fluxo de chamadas à UI.

### 🧠 ViewModels
- `MainViewModel.kt`: Controlador da tela principal (pager + título dinâmico).
- `CallsViewModel.kt`: Responsável por expor chamadas favoritas e recentes à UI.
- `ChatsViewModel.kt`: Base para futuras operações da tela de conversas.
- `StatusViewModel.kt`: Estrutura para lógica de exibição dos status dos contatos.

### 🧩 Refatorações de pacotes
- `WhatsAppTab.kt`: Movido para pasta `home` raiz.
- `CallsScreen.kt`: Movido para `home/calls/`.
- `StatusScreen.kt`: Movido para `home/status/`.

### 🛠️ Utilitário
- `StringUtils.kt`: Adicionado helper para `emptyString()`.

---

## 🧱 Organização e Arquitetura

A estrutura passou a seguir o padrão recomendado por features, separando responsabilidades:

```
├── data/
│   └── local/ / repository/
├── domain/
│   └── repository/ / usecase/
├── ui/
│   └── home/
│       ├── chats/
│       ├── calls/
│       └── status/
```

---

## 📌 Observações
- Koin foi configurado para injetar `CallsViewModel` com `GetCallsUseCase`.
- A tela de chamadas agora consome dados via `StateFlow` com tratamento de erro.
- Código preparado para extensão futura com fontes reais de dados (API ou Room).

---
