### PR TITLE
🧱 Continuação da Arquitetura MVVM – Chats e Status

### DIFF
--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/local/CallsDataSourceMock.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/local/CallsDataSourceMock.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 class CallsDataSourceMock {
-    fun fetchCalls(): Flow<List<CallItem>> = flowOf(sampleCalls)
+    fun getCalls(): Flow<List<CallItem>> = flowOf(sampleCalls)
 }
 
 val sampleCalls = listOf(

--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/local/ChatsDataSourceMock.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/local/ChatsDataSourceMock.kt
@@ -1,0 +1,40 @@
+package com.murilospinello2025.androidcompose.data.local
+
+import com.murilospinello2025.androidcompose.domain.model.ChatItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class ChatsDataSourceMock {
+    fun getChats(): Flow<List<ChatItem>> = flowOf(sampleChats)
+}
+
+val sampleChats = listOf(
+    ChatItem(
+        senderName = "Murilo",
+        lastMessage = "E aí, já terminou o app clone?",
+        time = "12:45",
+        unreadCount = 2,
+        profileImageUrl = "https://i.pinimg.com/236x/19/8a/bd/198abd0730e616bf1c3afc692d16f2ac.jpg"
+    ),
+    ChatItem(
+        senderName = "Estenio",
+        lastMessage = "Beleza, vamos marcar pra amanhã!",
+        time = "11:30",
+        unreadCount = 0,
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    ChatItem(
+        senderName = "Nayara",
+        lastMessage = "Vou te mandar os arquivos aqui",
+        time = "Ontem",
+        unreadCount = 1,
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg"
+    ),
+    ChatItem(
+        senderName = "Herick",
+        lastMessage = "Olha essa conversa aqui",
+        time = "Ontem",
+        unreadCount = 1,
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    )
+)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/local/StatusDataSourceMock.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/local/StatusDataSourceMock.kt
@@ -1,0 +1,31 @@
+package com.murilospinello2025.androidcompose.data.local
+
+import com.murilospinello2025.androidcompose.domain.model.StatusItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class StatusDataSourceMock {
+    fun getStatus(): Flow<List<StatusItem>> = flowOf(sampleStatus)
+}
+
+val sampleStatus = listOf(
+    StatusItem.MyStatus,
+    StatusItem.ContactStatus(
+        id = "1",
+        name = "Estenio",
+        time = "há 10 min",
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    StatusItem.ContactStatus(
+        id = "2",
+        name = "Nayara",
+        time = "há 23 min",
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg"
+    ),
+    StatusItem.ContactStatus(
+        id = "3",
+        name = "Herick",
+        time = "há 1h",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    )
+)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/CallsRepositoryImpl.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/CallsRepositoryImpl.kt
@@ -3,11 +3,12 @@ package com.murilospinello2025.androidcompose.data.repository
 
 import com.murilospinello2025.androidcompose.data.local.CallsDataSourceMock
 import com.murilospinello2025.androidcompose.domain.model.CallItem
+import com.murilospinello2025.androidcompose.domain.model.ChatItem
 import com.murilospinello2025.androidcompose.domain.repository.CallsRepository
 import kotlinx.coroutines.flow.Flow
 
 class CallsRepositoryImpl(
     private val dataSource: CallsDataSourceMock
 ) : CallsRepository {
-    override fun getCalls(): Flow<List<CallItem>> = dataSource.fetchCalls()
+    override fun getCalls(): Flow<List<CallItem>> = dataSource.getCalls()
 }

--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/ChatsRepositoryImpl.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/ChatsRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.murilospinello2025.androidcompose.data.repository
+
+
+import com.murilospinello2025.androidcompose.data.local.ChatsDataSourceMock
+import com.murilospinello2025.androidcompose.domain.model.ChatItem
+import com.murilospinello2025.androidcompose.domain.repository.ChatsRepository
+import kotlinx.coroutines.flow.Flow
+
+class ChatsRepositoryImpl(
+    private val dataSource: ChatsDataSourceMock
+) : ChatsRepository {
+    override fun getChats(): Flow<List<ChatItem>> = dataSource.getChats()
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/StatusRepositoryImpl.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/data/repository/StatusRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.murilospinello2025.androidcompose.data.repository
+
+
+import com.murilospinello2025.androidcompose.data.local.StatusDataSourceMock
+import com.murilospinello2025.androidcompose.domain.model.StatusItem
+import com.murilospinello2025.androidcompose.domain.repository.StatusRepository
+import kotlinx.coroutines.flow.Flow
+
+class StatusRepositoryImpl(
+    private val dataSource: StatusDataSourceMock
+) : StatusRepository {
+    override fun getStatus(): Flow<List<StatusItem>> = dataSource.getStatus()
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/di/AppModule.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/di/AppModule.kt
@@ -1,9 +1,17 @@
 package com.murilospinello2025.androidcompose.di
 
 import com.murilospinello2025.androidcompose.data.local.CallsDataSourceMock
+import com.murilospinello2025.androidcompose.data.local.ChatsDataSourceMock
+import com.murilospinello2025.androidcompose.data.local.StatusDataSourceMock
 import com.murilospinello2025.androidcompose.data.repository.CallsRepositoryImpl
+import com.murilospinello2025.androidcompose.data.repository.ChatsRepositoryImpl
+import com.murilospinello2025.androidcompose.data.repository.StatusRepositoryImpl
 import com.murilospinello2025.androidcompose.domain.repository.CallsRepository
+import com.murilospinello2025.androidcompose.domain.repository.ChatsRepository
+import com.murilospinello2025.androidcompose.domain.repository.StatusRepository
 import com.murilospinello2025.androidcompose.domain.usecase.GetCallsUseCase
+import com.murilospinello2025.androidcompose.domain.usecase.GetChatsUseCase
+import com.murilospinello2025.androidcompose.domain.usecase.GetStatusUseCase
 import com.murilospinello2025.androidcompose.ui.home.MainViewModel
 import com.murilospinello2025.androidcompose.ui.home.calls.CallsViewModel
 import com.murilospinello2025.androidcompose.ui.home.chats.ChatsViewModel
@@ -21,6 +29,14 @@ val appModule = module {
     viewModelOf(::StatusViewModel)
 
     singleOf(::GetCallsUseCase)
+    singleOf(::GetChatsUseCase)
+    singleOf(::GetStatusUseCase)
+
     singleOf(::CallsRepositoryImpl) bind CallsRepository::class
+    singleOf(::ChatsRepositoryImpl) bind ChatsRepository::class
+    singleOf(::StatusRepositoryImpl) bind StatusRepository::class
+
     singleOf(::CallsDataSourceMock)
+    singleOf(::ChatsDataSourceMock)
+    singleOf(::StatusDataSourceMock)
 }

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/ChatItem.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/ChatItem.kt
@@ -8,33 +8,3 @@ class ChatItem(
     val profileImageUrl: String
 )
 
-val sampleChats = listOf(
-    ChatItem(
-        senderName = "Murilo",
-        lastMessage = "E aí, já terminou o app clone?",
-        time = "12:45",
-        unreadCount = 2,
-        profileImageUrl = "https://i.pinimg.com/236x/19/8a/bd/198abd0730e616bf1c3afc692d16f2ac.jpg"
-    ),
-    ChatItem(
-        senderName = "Estenio",
-        lastMessage = "Beleza, vamos marcar pra amanhã!",
-        time = "11:30",
-        unreadCount = 0,
-        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
-    ),
-    ChatItem(
-        senderName = "Nayara",
-        lastMessage = "Vou te mandar os arquivos aqui",
-        time = "Ontem",
-        unreadCount = 1,
-        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg"
-    ),
-    ChatItem(
-        senderName = "Herick",
-        lastMessage = "Olha essa conversa aqui",
-        time = "Ontem",
-        unreadCount = 1,
-        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
-    )
-)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/StatusItem.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/model/StatusItem.kt
@@ -10,26 +10,3 @@ sealed class StatusItem {
 
     data object MyStatus : StatusItem()
 }
-
-
-val sampleStatuses = listOf(
-    StatusItem.MyStatus,
-    StatusItem.ContactStatus(
-        id = "1",
-        name = "Estenio",
-        time = "há 10 min",
-        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
-    ),
-    StatusItem.ContactStatus(
-        id = "2",
-        name = "Nayara",
-        time = "há 23 min",
-        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg"
-    ),
-    StatusItem.ContactStatus(
-        id = "3",
-        name = "Herick",
-        time = "há 1h",
-        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
-    )
-)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/repository/ChatsRepository.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/repository/ChatsRepository.kt
@@ -1,0 +1,8 @@
+package com.murilospinello2025.androidcompose.domain.repository
+
+import com.murilospinello2025.androidcompose.domain.model.ChatItem
+import kotlinx.coroutines.flow.Flow
+
+interface ChatsRepository {
+    fun getChats(): Flow<List<ChatItem>>
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/repository/StatusRepository.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/repository/StatusRepository.kt
@@ -1,0 +1,8 @@
+package com.murilospinello2025.androidcompose.domain.repository
+
+import com.murilospinello2025.androidcompose.domain.model.StatusItem
+import kotlinx.coroutines.flow.Flow
+
+interface StatusRepository {
+    fun getStatus(): Flow<List<StatusItem>>
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/usecase/GetChatsUseCase.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/usecase/GetChatsUseCase.kt
@@ -1,0 +1,9 @@
+package com.murilospinello2025.androidcompose.domain.usecase
+
+import com.murilospinello2025.androidcompose.domain.model.ChatItem
+import com.murilospinello2025.androidcompose.domain.repository.ChatsRepository
+import kotlinx.coroutines.flow.Flow
+
+class GetChatsUseCase(private val repository: ChatsRepository) {
+    operator fun invoke(): Flow<List<ChatItem>> = repository.getChats()
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/domain/usecase/GetStatusUseCase.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/domain/usecase/GetStatusUseCase.kt
@@ -1,0 +1,9 @@
+package com.murilospinello2025.androidcompose.domain.usecase
+
+import com.murilospinello2025.androidcompose.domain.model.StatusItem
+import com.murilospinello2025.androidcompose.domain.repository.StatusRepository
+import kotlinx.coroutines.flow.Flow
+
+class GetStatusUseCase(private val repository: StatusRepository) {
+    operator fun invoke(): Flow<List<StatusItem>> = repository.getStatus()
+}

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/calls/CallsViewModel.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/calls/CallsViewModel.kt
@@ -4,11 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.murilospinello2025.androidcompose.domain.model.CallItem
 import com.murilospinello2025.androidcompose.domain.usecase.GetCallsUseCase
-import com.murilospinello2025.emptyString
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.stateIn
 

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/chats/ChatsScreen.kt
@@ -18,29 +18,43 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
 import com.murilospinello2025.androidcompose.domain.model.ChatItem
-import com.murilospinello2025.androidcompose.domain.model.sampleChats
 import com.murilospinello2025.androidcompose.ui.theme.Dimens
 import org.koin.androidx.compose.koinViewModel
 
-@Preview
 @Composable
 fun ChatsScreen() {
     val viewModel: ChatsViewModel = koinViewModel()
+    val chats by viewModel.chats.collectAsStateWithLifecycle()
+    ChatsScreenColumn(chats)
+}
+
+@Preview
+@Composable
+fun ChatsScreenPreview() {
+    ChatsScreenColumn(sampleChatsPreview)
+}
+
+@Composable
+fun ChatsScreenColumn(
+    list: List<ChatItem>
+) {
     val horizontalColorDivider = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f)
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(vertical = Dimens.spacingS)
     ) {
-        sampleChats.forEach {
+        list.forEach {
             item {
                 ChatRow(chat = it)
                 HorizontalDivider(
@@ -101,3 +115,34 @@ fun ChatRow(chat: ChatItem) {
         }
     }
 }
+
+private val sampleChatsPreview = listOf(
+    ChatItem(
+        senderName = "Murilo",
+        lastMessage = "E aí, já terminou o app clone?",
+        time = "12:45",
+        unreadCount = 2,
+        profileImageUrl = "https://i.pinimg.com/236x/19/8a/bd/198abd0730e616bf1c3afc692d16f2ac.jpg"
+    ),
+    ChatItem(
+        senderName = "Estenio",
+        lastMessage = "Beleza, vamos marcar pra amanhã!",
+        time = "11:30",
+        unreadCount = 0,
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    ChatItem(
+        senderName = "Nayara",
+        lastMessage = "Vou te mandar os arquivos aqui",
+        time = "Ontem",
+        unreadCount = 1,
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg"
+    ),
+    ChatItem(
+        senderName = "Herick",
+        lastMessage = "Olha essa conversa aqui",
+        time = "Ontem",
+        unreadCount = 1,
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    )
+)

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusScreen.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusScreen.kt
@@ -11,36 +11,48 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
 import com.murilospinello2025.androidcompose.domain.model.StatusItem
-import com.murilospinello2025.androidcompose.domain.model.sampleStatuses
 import com.murilospinello2025.androidcompose.ui.theme.Dimens
 import org.koin.androidx.compose.koinViewModel
 
-@Preview
 @Composable
 fun StatusScreen() {
     val viewModel: StatusViewModel = koinViewModel()
+    val status by viewModel.status.collectAsStateWithLifecycle()
+    StatusScreenColumn(status)
+}
 
+@Preview(showBackground = true)
+@Composable
+fun StatusScreenPreview() {
+    StatusScreenColumn(sampleStatusPreview)
+}
+
+@Composable
+fun StatusScreenColumn(status : List<StatusItem>) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(vertical = Dimens.spacingS)
     ) {
-        items(sampleStatuses) { status ->
-            when (status) {
-                is StatusItem.MyStatus -> MyStatusItem()
-                is StatusItem.ContactStatus -> ContactStatusItem(status)
+        status.forEach { status ->
+            item {
+                when (status) {
+                    is StatusItem.MyStatus -> MyStatusItem()
+                    is StatusItem.ContactStatus -> ContactStatusItem(status)
+                }
             }
         }
     }
@@ -110,5 +122,28 @@ fun ContactStatusItem(status: StatusItem.ContactStatus) {
         }
     }
 }
+
+private val sampleStatusPreview = listOf(
+    StatusItem.MyStatus,
+    StatusItem.ContactStatus(
+        id = "1",
+        name = "Estenio",
+        time = "há 10 min",
+        profileImageUrl = "https://www.psitto.com.br/wp-content/uploads/2021/01/como-conviver-pessoas-dificeis.jpg"
+    ),
+    StatusItem.ContactStatus(
+        id = "2",
+        name = "Nayara",
+        time = "há 23 min",
+        profileImageUrl = "https://www.pensarcontemporaneo.com/content/uploads/2023/01/image-1.jpg"
+    ),
+    StatusItem.ContactStatus(
+        id = "3",
+        name = "Herick",
+        time = "há 1h",
+        profileImageUrl = "https://i.pinimg.com/736x/fd/fc/ef/fdfcefc24e58a4e3ed4dd6099d530353.jpg"
+    )
+)
+
 
 

--- a/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusViewModel.kt
+++ b/app/src/main/java/com/murilospinello2025/androidcompose/ui/home/status/StatusViewModel.kt
@@ -1,20 +1,28 @@
 package com.murilospinello2025.androidcompose.ui.home.status
 
 import androidx.lifecycle.ViewModel
-import com.murilospinello2025.emptyString
+import androidx.lifecycle.viewModelScope
+import com.murilospinello2025.androidcompose.domain.model.StatusItem
+import com.murilospinello2025.androidcompose.domain.usecase.GetStatusUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
 
-class StatusViewModel: ViewModel() {
+class StatusViewModel(getStatusUseCase: GetStatusUseCase): ViewModel() {
 
-    private val _titlePage = MutableStateFlow<String>(emptyString())
-    val titlePage = _titlePage.asStateFlow()
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
 
-    fun setTitlePage(title: String) {
-        _titlePage.value = "$TAG $title"
-    }
-
-    companion object {
-        private const val TAG = "Whatsapp"
-    }
+    val status: StateFlow<List<StatusItem>> = getStatusUseCase()
+        .catch { e ->
+            _error.value = e.message ?: "Erro desconhecido"
+            emit(emptyList())
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
 }


### PR DESCRIPTION
# 🧱 Continuação da Arquitetura MVVM – Chats e Status

Este Pull Request complementa a estrutura de camadas do projeto, agora introduzindo **módulos completos para as features de Chats e Status**, seguindo a arquitetura **Clean Architecture com Koin + Compose**.

---

## ✅ Alterações Realizadas

### 📦 Camada de dados

- `ChatsDataSourceMock.kt`: Fonte de dados mockada com informações de conversas simuladas.
- `StatusDataSourceMock.kt`: Fonte de dados mockada com os status do usuário e dos contatos.
- `ChatsRepositoryImpl.kt`: Implementação concreta da interface `ChatsRepository`, consumindo o mock.
- `StatusRepositoryImpl.kt`: Implementação da interface `StatusRepository`, consumindo o mock.

### 📦 Camada de domínio

- `ChatsRepository.kt`: Interface de abstração da feature de conversas.
- `StatusRepository.kt`: Interface de abstração da feature de status.
- `GetChatsUseCase.kt`: Caso de uso para obter a lista de conversas.
- `GetStatusUseCase.kt`: Caso de uso para obter o status do usuário e contatos.

---

## 🧱 Organização do Código

As novas features seguem a divisão modular adotada no projeto, garantindo:
- Facilidade de manutenção
- Testabilidade
- Substituição futura das fontes de dados mockadas por APIs ou Room

```
├── data/
│   ├── local/
│   │   ├── ChatsDataSourceMock.kt
│   │   └── StatusDataSourceMock.kt
│   └── repository/
│       ├── ChatsRepositoryImpl.kt
│       └── StatusRepositoryImpl.kt
├── domain/
│   ├── repository/
│   │   ├── ChatsRepository.kt
│   │   └── StatusRepository.kt
│   └── usecase/
│       ├── GetChatsUseCase.kt
│       └── GetStatusUseCase.kt
```

---

## 📌 Observações

- As novas fontes de dados estão prontas para alimentar `ViewModels` específicos por feature.
- Próximo passo: vincular os novos casos de uso às `ViewModels` de `Chats` e `Status`.
- As abstrações seguem o princípio da inversão de dependência.

---

Pull Request pronto para merge ✅